### PR TITLE
Add `ctfconfig.yml` to `ctf init`.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: CTF init
         run: |
-          ctf --no-update-check init test-ctf
+          ctf --no-update-check init test-ctf --name "NorthSec CTF CI"
 
       - name: Copy CTF files
         run: |

--- a/ctf/commands/init.py
+++ b/ctf/commands/init.py
@@ -1,7 +1,9 @@
+import datetime
 import importlib.resources
 import shutil
 from pathlib import Path
 
+import jinja2
 import typer
 from typing_extensions import Annotated
 
@@ -24,6 +26,13 @@ def init(
             "--force", help="Overwrite the directory if it's already initialized"
         ),
     ] = False,
+    name: Annotated[
+        str,
+        typer.Option(
+            help="Full display name of the CTF. Example: NorthSec CTF 2027",
+            prompt="CTF name (e.g. NorthSec CTF 2027)",
+        ),
+    ] = f"NorthSec CTF {datetime.datetime.now().year + 1}",
 ) -> None:
     # If path is not set, take the one from --location or CTF_ROOT_DIR, else it's the current directory.
     if not path:
@@ -47,12 +56,25 @@ def init(
             exit(1)
 
         with importlib.resources.path("ctf.templates", "init") as templates_location:
+            jinja_env = jinja2.Environment(
+                loader=jinja2.FileSystemLoader(
+                    searchpath=templates_location, encoding="utf-8"
+                ),
+                keep_trailing_newline=True,
+            )
             for asset in templates_location.iterdir():
-                dst_asset: Path = path / asset.name
-                if asset.is_dir():
+                if asset.suffix == ".j2":
+                    dst_asset = path / asset.stem
+                    content = jinja_env.get_template(asset.name).render(name=name)
+                    with dst_asset.open(mode="w", encoding="utf-8") as f:
+                        f.write(content)
+                    LOG.info(f'Created "{dst_asset}" file')
+                elif asset.is_dir():
+                    dst_asset = path / asset.name
                     shutil.copytree(asset, dst_asset, dirs_exist_ok=True)
                     LOG.info(f'Created "{dst_asset}" folder')
                 else:
+                    dst_asset = path / asset.name
                     shutil.copy(asset, dst_asset)
                     LOG.info(f'Created "{dst_asset}" file')
 

--- a/ctf/commands/validate.py
+++ b/ctf/commands/validate.py
@@ -13,7 +13,11 @@ from rich.progress import (
 )
 
 from ctf.common.logger import LOG
-from ctf.common.utils import find_ctf_root_directory, get_ctf_script_schemas_directory
+from ctf.common.utils import (
+    find_ctf_root_directory,
+    get_ctf_script_schemas_directory,
+    load_ctf_config,
+)
 from ctf.common.validators import ValidationError, validators_list
 from ctf.validate_json_schemas import validate_with_json_schemas
 
@@ -26,9 +30,17 @@ app = typer.Typer()
 def validate() -> None:
     LOG.info("Starting ctf validate...")
 
-    LOG.info(f"Found {len(validators_list)} Validators")
+    ctf_config = load_ctf_config()
+    active_validators = [
+        validator_class
+        for validator_class in validators_list
+        if validator_class.is_enabled(ctf_config)
+        and validator_class.__name__ not in ctf_config.disabled_validators
+    ]
 
-    validators = [validator_class() for validator_class in validators_list]
+    LOG.info(f"Found {len(active_validators)} Validators")
+
+    validators = [validator_class() for validator_class in active_validators]
 
     tracks = []
     for track in (find_ctf_root_directory() / "challenges").iterdir():

--- a/ctf/common/models.py
+++ b/ctf/common/models.py
@@ -147,12 +147,17 @@ class Frontend(StrEnum):
     DISCOURSE = "discourse"
 
 
+class ScoringSystem(StrEnum):
+    CFSS = "cfss"
+    OTHER = "other"
+
+
 class CtfConfig(BaseModel):
     """
     ctfconfig.yaml is parsed into this model.
     """
 
     name: str | None = None
-    uses_cfss: bool = True
+    scoring_system: ScoringSystem = ScoringSystem.CFSS
     frontend: Frontend | None = Frontend.DISCOURSE
     disabled_validators: list[str] = []

--- a/ctf/common/models.py
+++ b/ctf/common/models.py
@@ -140,3 +140,14 @@ class TrackYaml(BaseModel):
     contacts: TrackContacts
     instances: TrackInstances | None = None
     flags: list[TrackFlag]
+
+
+class CtfConfig(BaseModel):
+    """
+    ctfconfig.yaml is parsed into this model.
+    """
+
+    name: str | None = None
+    uses_cfss: bool = True
+    frontend: Literal["discourse"] | None = "discourse"
+    disabled_validators: list[str] = []

--- a/ctf/common/models.py
+++ b/ctf/common/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from pydantic import (
@@ -142,6 +143,10 @@ class TrackYaml(BaseModel):
     flags: list[TrackFlag]
 
 
+class Frontend(StrEnum):
+    DISCOURSE = "discourse"
+
+
 class CtfConfig(BaseModel):
     """
     ctfconfig.yaml is parsed into this model.
@@ -149,5 +154,5 @@ class CtfConfig(BaseModel):
 
     name: str | None = None
     uses_cfss: bool = True
-    frontend: Literal["discourse"] | None = "discourse"
+    frontend: Frontend | None = Frontend.DISCOURSE
     disabled_validators: list[str] = []

--- a/ctf/common/utils.py
+++ b/ctf/common/utils.py
@@ -13,7 +13,7 @@ import yaml
 
 from ctf import ENV
 from ctf.common.logger import LOG
-from ctf.common.models import Track, TrackYaml
+from ctf.common.models import CtfConfig, Track, TrackYaml
 
 __CTF_ROOT_DIRECTORY: Path | None = None
 
@@ -413,6 +413,14 @@ def show_version(value: bool) -> None:
     if value:
         typer.echo(f"ctf-script v{get_version()}")
         raise typer.Exit()
+
+
+def load_ctf_config():
+
+    config_path = find_ctf_root_directory() / "ctfconfig.yaml"
+    if not config_path.exists():
+        return CtfConfig()
+    return CtfConfig.model_validate(load_yaml_file(config_path) or {})
 
 
 def terraform_binary() -> Path:

--- a/ctf/common/validators.py
+++ b/ctf/common/validators.py
@@ -4,7 +4,7 @@ import os
 import re
 from pathlib import Path
 
-from ctf.common.models import CtfConfig, TrackYaml, ValidationError
+from ctf.common.models import CtfConfig, ScoringSystem, TrackYaml, ValidationError
 from ctf.common.utils import (
     find_ctf_root_directory,
     get_all_file_paths_recursively,
@@ -472,7 +472,7 @@ class CFSSStringValidator(Validator):
 
     @classmethod
     def is_enabled(cls, config: CtfConfig) -> bool:
-        return config.uses_cfss
+        return config.scoring_system == ScoringSystem.CFSS
 
     CFSS_VALUE_REGEX = re.compile(
         r"^CFSS:[0-9]\.[0-9][0-9]?/TS:[LBIA]/E:[LMH]/HSFC:[NY]=([0-9][0-9]?-[0-9][0-9]?)$"

--- a/ctf/common/validators.py
+++ b/ctf/common/validators.py
@@ -4,7 +4,7 @@ import os
 import re
 from pathlib import Path
 
-from ctf.common.models import TrackYaml, ValidationError
+from ctf.common.models import CtfConfig, TrackYaml, ValidationError
 from ctf.common.utils import (
     find_ctf_root_directory,
     get_all_file_paths_recursively,
@@ -21,6 +21,10 @@ class Validator(abc.ABC):
 
     def finalize(self) -> list[ValidationError]:
         return []
+
+    @classmethod
+    def is_enabled(cls, config: CtfConfig) -> bool:
+        return True
 
 
 class FilesValidator(Validator):
@@ -91,6 +95,10 @@ class FlagsValidator(Validator):
 
 class FireworksAskGodTagValidator(Validator):
     """Validate that ui_sound and ui_gif tags of each flag in track.yaml also as a file associated."""
+
+    @classmethod
+    def is_enabled(cls, config: CtfConfig) -> bool:
+        return config.frontend == "discourse"
 
     def __init__(self):
         self.sound_tags_mapping = {}
@@ -165,6 +173,10 @@ class DiscoursePostsAskGodTagValidator(Validator):
     Also validate that each discourse tag is unique.
     Also validates that the topic matches an existing file name in the posts directory.
     """
+
+    @classmethod
+    def is_enabled(cls, config: CtfConfig) -> bool:
+        return config.frontend == "discourse"
 
     def __init__(self):
         self.discourse_tags_mapping = {}
@@ -333,6 +345,10 @@ class PlaceholderValuesValidator(Validator):
 class DiscourseFileNamesValidator(Validator):
     """Validate that the discourse posts have unique file names."""
 
+    @classmethod
+    def is_enabled(cls, config: CtfConfig) -> bool:
+        return config.frontend == "discourse"
+
     def __init__(self):
         self.discourse_posts_mapping = {}
 
@@ -454,6 +470,10 @@ class OrphanServicesValidator(Validator):
 class CFSSStringValidator(Validator):
     """Validate the CFSS string of each flag in the track.yaml."""
 
+    @classmethod
+    def is_enabled(cls, config: CtfConfig) -> bool:
+        return config.uses_cfss
+
     CFSS_VALUE_REGEX = re.compile(
         r"^CFSS:[0-9]\.[0-9][0-9]?/TS:[LBIA]/E:[LMH]/HSFC:[NY]=([0-9][0-9]?-[0-9][0-9]?)$"
     )
@@ -512,6 +532,10 @@ class CFSSStringValidator(Validator):
 class HasAtLeastOneDiscoursePostValidator(Validator):
     """Validate that each track has at least one discourse post."""
 
+    @classmethod
+    def is_enabled(cls, config: CtfConfig) -> bool:
+        return config.frontend == "discourse"
+
     def validate(self, track_name: str) -> list[ValidationError]:
         errors: list[ValidationError] = []
         discourse_posts = parse_post_yamls(track_name=track_name)
@@ -536,6 +560,10 @@ class HasAtLeastOneDiscoursePostValidator(Validator):
 
 class TrailingSpacesForPostUser(Validator):
     """Validate that there is not trailing spaces for post users."""
+
+    @classmethod
+    def is_enabled(cls, config: CtfConfig) -> bool:
+        return config.frontend == "discourse"
 
     def validate(self, track_name: str) -> list[ValidationError]:
         errors: list[ValidationError] = []

--- a/ctf/templates/init/.vscode/settings.json
+++ b/ctf/templates/init/.vscode/settings.json
@@ -4,6 +4,7 @@
     },
     "yaml.schemas": {
         "schemas/track.yaml.json": "challenges/*/track.yaml",
-        "schemas/post.json": "challenges/*/posts/*.yaml"
+        "schemas/post.json": "challenges/*/posts/*.yaml",
+        "schemas/ctfconfig.json": "ctfconfig.yaml"
     }
 }

--- a/ctf/templates/init/README.md.j2
+++ b/ctf/templates/init/README.md.j2
@@ -1,4 +1,4 @@
-# CTF Name CHANGEME
+# {{ name }}
 
 This repository was generated using the [`ctf-script` tool](https://github.com/nsec/ctf-script). To contribute, install it first.
 

--- a/ctf/templates/init/ctfconfig.yaml.j2
+++ b/ctf/templates/init/ctfconfig.yaml.j2
@@ -1,7 +1,7 @@
 # Name of the CTF (like "NorthSec CTF 2027")
 name: {{ name }}
-# Setting it to false disables CFSS validators if the CTF doesn't use CFSS scoring.
-uses_cfss: true
+# Scoring system used by the CTF. Set it to "cfss" to enable CFSS validators, or "other" to disable them.
+scoring_system: cfss
 # Setting it to false disables discourse validators.
 frontend: discourse
 # List of validators to disable. Example: ["FilesValidator", "FlagsValidator"]

--- a/ctf/templates/init/ctfconfig.yaml.j2
+++ b/ctf/templates/init/ctfconfig.yaml.j2
@@ -1,0 +1,8 @@
+# Name of the CTF (like "NorthSec CTF 2027")
+name: {{ name }}
+# Setting it to false disables CFSS validators if the CTF doesn't use CFSS scoring.
+uses_cfss: true
+# Setting it to false disables discourse validators.
+frontend: discourse
+# List of validators to disable. Example: ["FilesValidator", "FlagsValidator"]
+disabled_validators: []

--- a/ctf/templates/init/schemas/ctfconfig.json
+++ b/ctf/templates/init/schemas/ctfconfig.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "CTF-wide configuration file.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Full display name of the CTF. Example: NorthSec CTF 2027"
+    },
+    "uses_cfss": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether the CTF uses CFSS scoring. When false, CFSS-specific validators are skipped."
+    },
+    "frontend": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["discourse"],
+          "description": "Frontend used by the CTF."
+        },
+        {
+          "type": "null",
+          "description": "No frontend. All discourse-related validators are skipped."
+        }
+      ],
+      "default": "discourse"
+    },
+    "disabled_validators": {
+      "type": "array",
+      "description": "List of validator class names to skip regardless of other settings. Example: OrphanServicesValidator",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "uniqueItems": true
+    }
+  }
+}

--- a/ctf/templates/init/schemas/ctfconfig.json
+++ b/ctf/templates/init/schemas/ctfconfig.json
@@ -8,10 +8,11 @@
       "type": "string",
       "description": "Full display name of the CTF. Example: NorthSec CTF 2027"
     },
-    "uses_cfss": {
-      "type": "boolean",
-      "default": true,
-      "description": "Whether the CTF uses CFSS scoring. When false, CFSS-specific validators are skipped."
+    "scoring_system": {
+      "type": "string",
+      "enum": ["cfss", "other"],
+      "default": "cfss",
+      "description": "Scoring system used by the CTF. When set to \"cfss\", CFSS-specific validators run; any other value (e.g. \"other\") skips them."
     },
     "frontend": {
       "oneOf": [


### PR DESCRIPTION
Add `ctfconfig.yml` to `ctf init`.
This config file allows disabling validators and setting the CTF name. Implements #42

Signed-off-by: Émilio Gonzalez <little.moon6016@fastmail.com>